### PR TITLE
Added inline attachment functionality

### DIFF
--- a/src/SimpleEmailServiceMessage.php
+++ b/src/SimpleEmailServiceMessage.php
@@ -2,6 +2,7 @@
 /**
 * SimpleEmailServiceMessage PHP class
 *
+* @link https://github.com/daniel-zahariev/php-aws-ses
 * @version 0.8.3
 * @package AmazonSimpleEmailService
 */


### PR DESCRIPTION
Now inline images can be added like this:

$rawEmail->addAttachmentFromFile('logo.png','../logo.png','application/octet-stream', '<logo.png>' , 'inline');

and in the html version of the e-mail: <img src='cid:logo.png' />
